### PR TITLE
slim down mr fatty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM golang
+FROM golang:1.21.5-alpine
 
 RUN cd $(go env GOPATH) && curl -sL https://taskfile.dev/install.sh | sh
 RUN go install entgo.io/ent/cmd/ent@latest
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-RUN go install github.com/hairyhenderson/gomplate/v4/cmd/gomplate@latest
 RUN go install go.uber.org/mock/mockgen@latest
+
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2
+
+COPY --from=hairyhenderson/gomplate:stable /gomplate /bin/gomplate
 
 COPY . .


### PR DESCRIPTION
cuts image size down to ~500mb from 2gb by using binary installs

```
REPOSITORY                         TAG         IMAGE ID       CREATED          SIZE
datumbase                          local4      dd9fbbc700be   5 seconds ago    570MB
datumbase                          local3      d711c9e0dcb2   6 minutes ago    931MB
datumbase                          local2      6da48630c532   14 minutes ago   2.24GB
ghcr.io/datumforge/base-ci-image   main        70a68c17f168   29 hours ago     2.86GB
```