### PR TITLE
add mockery to base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ FROM golang:1.21.6-alpine
 RUN apk add git
 RUN go install github.com/go-task/task/v3/cmd/task@latest
 RUN go install entgo.io/ent/cmd/ent@latest
+
+# TODO: remove after gomock removed from datum repo
 RUN go install go.uber.org/mock/mockgen@latest
 
 RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2
+
+COPY --from=vektra/mockery:v2 /usr/local/bin/mockery /bin/mockery
 
 COPY --from=hairyhenderson/gomplate:stable /gomplate /bin/gomplate
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,7 @@
+version: '3'
+
+tasks:
+  build:
+    desc: builds the base-ci docker image
+    cmds:
+      - docker build -f Dockerfile .


### PR DESCRIPTION
In the process of switching our FGA mocks from gomock/mockgen to `testify` mock, and generate mocks with mockery: https://github.com/vektra/mockery. This PR adds mockery, but does not remove mockgen to ensure backwards compatibility