### PR TITLE
dont run the build step when its a tag

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -9,7 +9,7 @@ steps:
   steps:
   - label: ":docker: docker pr build"
     key: "docker-pr-build"
-    if: build.branch != "main"
+    if: build.branch != "main" && build.tag == null
     commands: |
       #!/bin/bash
       ls


### PR DESCRIPTION
`BUILDKITE_BRANCH` is equal to the `BUILDKITE_TAG` on tags, we dont need to run `docker` build when its built as part of build and tag step